### PR TITLE
Set website logo alt in the config

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -10,6 +10,7 @@ theme = "hugo-serif-theme"
   [params.logo]
     mobile = "/images/logo-mobile.svg"
     standard  = "/images/logo.svg"
+    alt = "Serif - A Hugo Business Theme"
 
   [params.homepage_meta_tags]
     meta_description = "Serif is a modern business theme for Hugo. It contains content types for the archetypical business website. The theme is fully responsive, blazing fast and artfully illustrated."

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,10 +1,10 @@
 <div class='header'>
   <div class="container">
     <div class="logo">
-      <a href="{{ .Site.BaseURL }}"><img alt="Logo" src="{{ .Site.Params.logo.standard | relURL }}" /></a>
+      <a href="{{ .Site.BaseURL }}"><img alt="{{ .Site.Params.logo.alt }}" src="{{ .Site.Params.logo.standard | relURL }}" /></a>
     </div>
     <div class="logo-mobile">
-      <a href="{{ .Site.BaseURL }}"><img alt="Logo" src="{{ .Site.Params.logo.mobile | relURL }}" /></a>
+      <a href="{{ .Site.BaseURL }}"><img alt="{{ .Site.Params.logo.alt }}" src="{{ .Site.Params.logo.mobile | relURL }}" /></a>
     </div>
     {{ partial "main-menu.html" . }}
     {{ partial "hamburger.html" . }}


### PR DESCRIPTION
Setting logo alt to text with desirable keywords is a good SEO practice, so I feel like this should be set in the config.