### PR TITLE
Add Google Tag Manager snippets

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -5,7 +5,9 @@ themesDir = "../.."
 theme = "hugo-serif-theme"
 
 [params]
+  # In most cases you will only want to use either one of these. If you have Google Analytics included in your GTM tags don't put your GA ID here. Otherwise your data might be useless.
   google_analytics_id = ""
+  google_tag_manager_id = ""
 
   [params.logo]
     mobile = "/images/logo-mobile.svg"

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+  {{ partial "google-tag-manager.html" . }}
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <title>{{ block "title" . }}{{ .Title }} - {{ .Site.Title }}{{ end }}</title>
@@ -25,6 +26,7 @@
 </head>
 
 <body class='page {{ block "body_classes" . }}{{ end }}'>
+  {{ partial "google-tag-manager-noscript.html" . }}
   {{ partial "main-menu-mobile.html" . }}
   <div class="wrapper">
     {{ partial "header.html" . }}

--- a/layouts/partials/google-tag-manager-noscript.html
+++ b/layouts/partials/google-tag-manager-noscript.html
@@ -1,0 +1,12 @@
+{{- if .Site.IsServer -}}
+<!-- Dont add Google Tag Manager to localhost -->
+{{ else }}
+{{ $gid := (getenv "HUGO_GTM_ID") }}
+{{ if $gid }}
+<!-- Google Tag Manager (noscript) --> <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{- $gid -}}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript> <!-- End Google Tag Manager (noscript) -->
+{{ else }}
+{{ if .Site.Params.google_tag_manager_id }}
+<!-- Google Tag Manager (noscript) --> <noscript><iframe src="https://www.googletagmanager.com/ns.html?id={{- .Site.Params.google_tag_manager_id -}}" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript> <!-- End Google Tag Manager (noscript) -->
+{{ end }}
+{{ end }}
+{{ end }}

--- a/layouts/partials/google-tag-manager.html
+++ b/layouts/partials/google-tag-manager.html
@@ -1,0 +1,12 @@
+{{- if .Site.IsServer -}}
+<!-- Dont add Google Tag Manager to localhost -->
+{{ else }}
+{{ $gid := (getenv "HUGO_GTM_ID") }}
+{{ if $gid }}
+<!-- Google Tag Manager --> <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','{{- $gid -}}');</script> <!-- End Google Tag Manager -->
+{{ else }}
+{{ if .Site.Params.google_tag_manager_id }}
+<!-- Google Tag Manager --> <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src= 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f); })(window,document,'script','dataLayer','{{- .Site.Params.google_tag_manager_id -}}');</script> <!-- End Google Tag Manager -->
+{{ end }}
+{{ end }}
+{{ end }}


### PR DESCRIPTION
Implemented the same way as Google Analytics, this will only include the snippets if `HUGO_GTM_ID` env variable or `google_tag_manager_id` in config is set.

Snippets are included right after opening <head> and <body> tags to ensure highest accuracy of data. Since both the javascript and iframe are loaded asynchronously it shouldn't impact loading times.