### PR TITLE
Hide empty space at the bottom of the main page when there are no features

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -51,7 +51,7 @@
 </div>
 {{end}}
 
-{{if ne .Site.Data.features nil}}
+{{if .Site.Data.features}}
 <div class="strip strip-grey">
   <div class="container pt-6 pb-6 pt-md-10 pb-md-10">
     <div class="row justify-content-center">

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -51,6 +51,7 @@
 </div>
 {{end}}
 
+{{if ne .Site.Data.features nil}}
 <div class="strip strip-grey">
   <div class="container pt-6 pb-6 pt-md-10 pb-md-10">
     <div class="row justify-content-center">
@@ -70,6 +71,8 @@
     </div>
   </div>
 </div>
+{{end}}
+
 {{ end }}
 
 {{ define "footer_js" }}


### PR DESCRIPTION
Steps to reproduce:
- Delete file `data/features.json` or leave it empty
- Open the main page
- There is empty space at the bottom of the page left from features block

This PR hides all unnecessary `div`s that supposed to hold features inside them.