### PR TITLE
Do not show email label in footer if there is email configured

### DIFF
--- a/layouts/partials/sub-footer.html
+++ b/layouts/partials/sub-footer.html
@@ -7,8 +7,10 @@
 {{ if .Site.Data.contact.phone }}
             <li><strong>Phone: </strong><span>{{ .Site.Data.contact.phone }}</span></li>
 {{ end }}
+{{ if .Site.Data.contact.email }}
             <li><strong>Email: </strong><a href="mailto:{{ .Site.Data.contact.email }}">
                 {{ .Site.Data.contact.email }}</a></li>
+{{ end }}
           </ul>
           <a class="zerostatic" href="https://www.zerostatic.io">www.zerostatic.io</a>
         </div>


### PR DESCRIPTION
If there is no e-mail configured in contacts then footer looks a little bit untidy

<img width="1680" alt="Screenshot 2020-05-28 at 11 50 17" src="https://user-images.githubusercontent.com/2471447/83120303-894b9200-a0d9-11ea-9bc0-fe30ea0d7d7c.png">
